### PR TITLE
Fix agent graph reference in langgraph config

### DIFF
--- a/apps/agent/langgraph.json
+++ b/apps/agent/langgraph.json
@@ -1,0 +1,9 @@
+{
+  "dependencies": [
+    "."
+  ],
+  "graphs": {
+    "agent": "./dist/agent.js:deepAgentGraph"
+  },
+  "env": ".env"
+}


### PR DESCRIPTION
## Summary
- point the agent graph entry to the compiled dist/agent.js file
- reference the correct exported graph name `deepAgentGraph`

## Testing
- not run (configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68db0062ffd8832381ca7563e6b63b81