### PR TITLE
Refine deep agent initialization and tooling

### DIFF
--- a/apps/agent/package.json
+++ b/apps/agent/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "deep-agents-app",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
+  },
+  "dependencies": {
+    "@langchain/google-genai": "^0.1.2",
+    "@langchain/mcp-adapters": "^0.6.0",
+    "@langchain/tavily": "^0.1.5",
+    "deepagents": "^1.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.0"
+  }
+}

--- a/apps/agent/src/agent.ts
+++ b/apps/agent/src/agent.ts
@@ -1,0 +1,74 @@
+import { Buffer } from "node:buffer";
+
+import { createDeepAgent } from "deepagents";
+import { ChatGoogleGenerativeAI } from "@langchain/google-genai";
+import { coerceMessageLikeToMessage } from "@langchain/core/messages";
+
+import { DEFAULT_AGENT_INSTRUCTIONS } from "./utils/nodes";
+import { loadDefaultTools } from "./utils/tools";
+import type { AgentFile, AgentRunInput } from "./utils/state";
+
+export type DeepAgentGraph = Awaited<ReturnType<typeof createDeepAgent>>;
+
+const model = new ChatGoogleGenerativeAI({
+  apiKey: process.env.GOOGLE_API_KEY ?? process.env.GOOGLE_GENAI_API_KEY,
+  model: process.env.GOOGLE_GENAI_MODEL ?? "gemini-2.5-pro",
+  temperature: 0.3,
+  maxOutputTokens: 2048,
+});
+
+let deepAgentGraphPromise: Promise<DeepAgentGraph> | null = null;
+
+export async function initDeepAgent(): Promise<DeepAgentGraph> {
+  if (!deepAgentGraphPromise) {
+    deepAgentGraphPromise = (async () => {
+      const tools = await loadDefaultTools();
+
+      return createDeepAgent({
+        model,
+        tools,
+        instructions:
+          process.env.DEEP_AGENT_INSTRUCTIONS ?? DEFAULT_AGENT_INSTRUCTIONS,
+      });
+    })();
+  }
+
+  return deepAgentGraphPromise;
+}
+
+export async function getDeepAgentGraph(): Promise<DeepAgentGraph> {
+  return initDeepAgent();
+}
+
+function normalizeFileContent(file: AgentFile): string {
+  if (typeof file.data === "string") {
+    return file.data;
+  }
+
+  const buffer = file.data instanceof Uint8Array
+    ? Buffer.from(file.data)
+    : Buffer.from(new Uint8Array(file.data));
+
+  const mimeType = file.mimeType ?? "application/octet-stream";
+  return `data:${mimeType};base64,${buffer.toString("base64")}`;
+}
+
+export async function invokeDeepAgent(input: AgentRunInput) {
+  const agent = await initDeepAgent();
+  const files = input.files?.length
+    ? Object.fromEntries(
+        input.files
+          .filter((file) => file.name)
+          .map((file) => [file.name, normalizeFileContent(file)])
+      )
+    : undefined;
+
+  return agent.invoke({
+    messages: input.messages.map((message) =>
+      coerceMessageLikeToMessage(message)
+    ),
+    files,
+  });
+}
+
+export type { AgentRunInput } from "./utils/state";

--- a/apps/agent/src/utils/nodes.ts
+++ b/apps/agent/src/utils/nodes.ts
@@ -1,0 +1,7 @@
+export const DEFAULT_AGENT_INSTRUCTIONS = `You are Deep Agent, a thoughtful AI assistant that is comfortable reasoning over structured tools and uploaded files.
+
+Follow these high level guidelines:
+- Think through the task step-by-step before acting.
+- When tools are available, decide if they are necessary before using them.
+- Reference any files that are provided to you as context when they appear relevant.
+- Keep responses concise but complete, surfacing citations or tool results when they matter.`;

--- a/apps/agent/src/utils/state.ts
+++ b/apps/agent/src/utils/state.ts
@@ -1,0 +1,14 @@
+import type { BaseMessageLike } from "@langchain/core/messages";
+
+export type AgentMessage = BaseMessageLike;
+
+export type AgentFile = {
+  name: string;
+  mimeType?: string;
+  data: Uint8Array | ArrayBuffer | string;
+};
+
+export interface AgentRunInput {
+  messages: AgentMessage[];
+  files?: AgentFile[];
+}

--- a/apps/agent/src/utils/tools.ts
+++ b/apps/agent/src/utils/tools.ts
@@ -1,0 +1,62 @@
+import { TavilySearch } from "@langchain/tavily";
+import { MultiServerMCPClient } from "@langchain/mcp-adapters";
+import type { StructuredTool } from "@langchain/core/tools";
+
+export type LoadedTool = StructuredTool;
+
+async function loadMcpTools(): Promise<LoadedTool[]> {
+  const serverUrl = process.env.MCP_SERVER_URL;
+
+  if (!serverUrl) {
+    return [];
+  }
+
+  const serverToken = process.env.MCP_SERVER_TOKEN ?? process.env.MCP_API_KEY;
+
+  const client = new MultiServerMCPClient({
+    mcpServers: {
+      default: {
+        transport: "sse",
+        url: serverUrl,
+        headers: serverToken
+          ? {
+              Authorization: `Bearer ${serverToken}`,
+            }
+          : undefined,
+      },
+    },
+  });
+
+  try {
+    await client.initializeConnections();
+    const tools = await client.getTools();
+
+    if (Array.isArray(tools)) {
+      return tools;
+    }
+  } catch (error) {
+    console.warn("Failed to initialize MCP tools", error);
+  } finally {
+    await client.close?.();
+  }
+
+  return [];
+}
+
+export async function loadDefaultTools(): Promise<LoadedTool[]> {
+  const tools: LoadedTool[] = [];
+
+  if (process.env.TAVILY_API_KEY) {
+    tools.push(
+      new TavilySearch({
+        tavilyApiKey: process.env.TAVILY_API_KEY,
+        maxResults: 5,
+      })
+    );
+  }
+
+  const mcpTools = await loadMcpTools();
+  tools.push(...mcpTools);
+
+  return tools;
+}

--- a/apps/agent/tsconfig.json
+++ b/apps/agent/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "ES2022",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- lazily initialize the Gemini-powered deep agent graph and normalize attachments before invocation
- align the agent input types with LangChain message coercion and convert uploaded files into Deep Agents file records
- load Tavily and MCP tools through supported adapters and update dependencies to published versions

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68db0028f2fc8323abb40581e907e7e8