### PR TITLE
docs: refresh agent documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,47 @@
 # Deep Agents Monorepo
 
-This repository scaffolds the workspace layout for a LangGraph agent package and a Next.js application. Implementation details wi
-ll be added in later milestones.
+This repository hosts the Deep Agents LangGraph runtime alongside a lightweight Next.js proxy used to surface the agent over HTTP. The project is organized as an npm workspace so each package can be developed and deployed independently while sharing tooling.
 
-## Structure
+## Packages
 
-- `apps/agent`: Placeholder LangGraph agent package with source directories and configuration files.
-- `apps/web`: Placeholder Next.js application with a stub API route for the LangGraph proxy.
+- **apps/agent** – LangGraph agent that orchestrates subagents, default tools, and Gemini-based reasoning workflows.
+- **apps/web** – Next.js 14 application that exposes API routes bridging web clients to the agent runtime.
+
+## Prerequisites
+
+- Node.js 20 or newer (matching the workspace `engines` field)
+- npm 10+ (ships with Node 20)
+- A Google Generative AI API key for agent execution (`GOOGLE_API_KEY` or `GOOGLE_GENAI_API_KEY`)
 
 ## Getting Started
 
-Install dependencies with your preferred package manager once subsequent milestones add runnable code.
+1. Install workspace dependencies:
+
+   ```bash
+   npm install
+   ```
+
+2. Create environment files where needed. For the agent, copy `apps/agent/.env.example` to `apps/agent/.env` and provide the required Google credentials.
+
+3. Launch both packages in development mode:
+
+   ```bash
+   npm run dev --workspaces
+   ```
+
+   Use `npm run dev --workspace apps/agent` or `npm run dev --workspace apps/web` to focus on a single package.
+
+4. Run linting or formatting from the repo root:
+
+   ```bash
+   npm run lint
+   npm run format
+   ```
+
+## Additional Resources
+
+- [docs-by-langchain.md](docs-by-langchain.md) – High-level LangChain integration notes.
+- [langgraph-js.md](langgraph-js.md) / [langchain-js.md](langchain-js.md) – Reference material for the JavaScript ecosystem used in this project.
+- [MCP-SERVERS.md](MCP-SERVERS.md) – Details on Model Context Protocol server interactions.
+
+For package-specific instructions, see the README files inside each workspace (for example, [`apps/agent/README.md`](apps/agent/README.md)).

--- a/apps/agent/README.md
+++ b/apps/agent/README.md
@@ -1,0 +1,54 @@
+# Deep Agent Runtime
+
+The `apps/agent` workspace hosts the LangGraph runtime that powers Deep Agents. It stitches together Google Gemini models, shared tools, and specialized subagents so the system can reason over user prompts and optional file attachments.
+
+## Project Layout
+
+- `src/agent.ts` – Entry point that creates the Deep Agent graph, configures the Gemini model, and exposes the LangGraph server export.
+- `src/utils/tools.ts` – Loads the default LangChain tools (Tavily, file helpers, etc.) and configures optional MCP servers.
+- `src/utils/nodes.ts` – Defines subagent nodes and default research instructions consumed by the graph.
+- `src/utils/state.ts` – Shapes the run input and file data that flow through the agent.
+- `langgraph.json` – Declares the build output and `.env` file consumed by the LangGraph CLI.
+
+## Prerequisites
+
+- Node.js 20+
+- npm 10+
+- Access to the Google Generative AI API (Gemini)
+
+## Environment Variables
+
+Create a `.env` file by copying `.env.example` and filling in the relevant keys:
+
+```bash
+cp .env.example .env
+```
+
+Key settings include:
+
+- `GOOGLE_API_KEY` or `GOOGLE_GENAI_API_KEY` – Required to authenticate with Gemini.
+- `GOOGLE_GENAI_MODEL` – Optional override for the default `gemini-2.5-pro` model.
+- `TAVILY_API_KEY` – Optional key to enable Tavily search integration.
+- `DEEP_AGENT_INSTRUCTIONS` – Custom top-level instructions if you want to replace the bundled research prompt.
+- `LANGGRAPH_SERVER_TOKEN` – Token used when deploying to LangGraph Cloud.
+
+Refer to the inline comments in `.env.example` for additional MCP server guidance.
+
+## Development Workflow
+
+Install dependencies from the monorepo root (`npm install`) and then use the following commands within this workspace:
+
+- `npm run dev --workspace apps/agent` – Start the LangGraph development server with hot reload.
+- `npm run typecheck --workspace apps/agent` – Run TypeScript type checking without emitting output.
+- `npm run build --workspace apps/agent` – Compile TypeScript to `dist/` for production or LangGraph packaging.
+- `npm run build:server --workspace apps/agent` – Generate LangGraph server artifacts using the CLI.
+
+The CLI commands rely on `langgraph.json` to locate the compiled graph export (`deepAgentGraph`) and environment file.
+
+## Customization Tips
+
+- Update `src/utils/tools.ts` to add or remove LangChain tools and MCP servers.
+- Adjust `src/utils/nodes.ts` to register additional subagents or tweak routing logic.
+- Override the default agent instructions via the `DEEP_AGENT_INSTRUCTIONS` environment variable when deploying specialized behaviors.
+
+After making changes, rebuild or restart the dev server to ensure the graph reflects the latest configuration.


### PR DESCRIPTION
## Summary
- expand the root README with prerequisites, workspace commands, and documentation references
- add a dedicated README for the LangGraph agent workspace covering layout, environment, and workflows

## Testing
- not run (documentation only)

------
https://chatgpt.com/codex/tasks/task_e_68db4242704883238c12f7508c54fc03