### PR TITLE
fix: harden exa search integration

### DIFF
--- a/apps/agent/package.json
+++ b/apps/agent/package.json
@@ -14,10 +14,11 @@
   "dependencies": {
     "@langchain/core": "^0.3.78",
     "@langchain/google-genai": "^0.2.18",
+    "@langchain/langgraph-sdk": "^0.1.9",
     "@langchain/mcp-adapters": "^0.6.0",
     "@langchain/tavily": "^0.1.5",
     "deepagents": "^0.0.2",
-    "@langchain/langgraph-sdk": "^0.1.0",
+    "exa-js": "^1.9.3",
     "jose": "^5.9.3"
   },
   "devDependencies": {

--- a/apps/agent/src/agent.ts
+++ b/apps/agent/src/agent.ts
@@ -9,6 +9,7 @@ import { RESEARCH_AGENT_INSTRUCTIONS, subAgents } from "./utils/nodes.js";
 import type { AgentFile, AgentRunInput } from "./utils/state.js";
 
 export type DeepAgentGraph = Awaited<ReturnType<typeof createDeepAgent>>;
+export type DeepAgentRunResult = Awaited<ReturnType<DeepAgentGraph["invoke"]>>;
 
 const model = createAgentModel();
 
@@ -49,7 +50,9 @@ function normalizeFileContent(file: AgentFile): string {
   return `data:${mimeType};base64,${buffer.toString("base64")}`;
 }
 
-export async function invokeDeepAgent(input: AgentRunInput) {
+export async function invokeDeepAgent(
+  input: AgentRunInput
+): Promise<DeepAgentRunResult> {
   const agent = await initDeepAgent();
   const files = input.files?.length
     ? Object.fromEntries(
@@ -70,4 +73,4 @@ export async function invokeDeepAgent(input: AgentRunInput) {
 export type { AgentRunInput } from "./utils/state.js";
 
 // Export for LangGraph Server consumption (required by langgraph.json)
-export const deepAgentGraph = await initDeepAgent();
+export const deepAgentGraph: DeepAgentGraph = await initDeepAgent();

--- a/apps/agent/src/agents/deep-research/tools.ts
+++ b/apps/agent/src/agents/deep-research/tools.ts
@@ -1,12 +1,233 @@
 // Deep Research Agent specific tools
 import { TavilySearch } from "@langchain/tavily";
 import { tool, type StructuredTool } from "@langchain/core/tools";
+import Exa from "exa-js";
 import { z } from "zod";
 import { loadMcpTools } from "../../utils/mcp.js";
 
 export type LoadedTool = StructuredTool;
 
 type InternetSearchTopic = "general" | "news" | "finance";
+
+const EXA_CATEGORY = z.enum([
+  "company",
+  "research paper",
+  "news",
+  "github",
+  "tweet",
+  "movie",
+  "song",
+  "personal site",
+  "pdf",
+]);
+
+type ExaCategory = z.infer<typeof EXA_CATEGORY>;
+
+type ExaClient = InstanceType<typeof Exa>;
+type ExaSearchResponse = Awaited<ReturnType<ExaClient["searchAndContents"]>>;
+type ExaSearchResult = ExaSearchResponse["results"][number];
+type ExaSubpage = NonNullable<ExaSearchResult["subpages"]>[number];
+
+export const exaSearch = tool(
+  async ({
+    query,
+    numResults = 10,
+    type = "auto",
+    includeText = true,
+    includeHighlights = true,
+    highlightQuery,
+    numHighlightSentences = 4,
+    summaryQuery,
+    subpages = 0,
+    subpageTargets,
+    livecrawl = "always",
+    category,
+    startCrawlDate,
+    endCrawlDate,
+  }: {
+    query: string;
+    numResults?: number;
+    type?: "auto" | "neural" | "keyword";
+    includeText?: boolean;
+    includeHighlights?: boolean;
+    highlightQuery?: string;
+    numHighlightSentences?: number;
+    summaryQuery?: string;
+    subpages?: number;
+    subpageTargets?: string[];
+    livecrawl?: "always" | "never" | "asAvailable";
+    category?: ExaCategory;
+    startCrawlDate?: string;
+    endCrawlDate?: string;
+  }) => {
+    if (!process.env.EXA_API_KEY) {
+      const errorMsg = "EXA_API_KEY is not configured. Exa search is unavailable.";
+      console.error(errorMsg);
+      return {
+        error: errorMsg,
+        results: [],
+        query,
+        message:
+          "Exa search tool is unavailable. Please continue with other available information.",
+      };
+    }
+
+    try {
+      const exa = new Exa(process.env.EXA_API_KEY!);
+
+      const contents: Record<string, unknown> = {};
+      if (includeText) {
+        contents.text = true;
+      }
+      if (includeHighlights) {
+        contents.highlights = {
+          query: highlightQuery ?? query,
+          numSentences: numHighlightSentences,
+        };
+      }
+      if (summaryQuery) {
+        contents.summary = {
+          query: summaryQuery,
+        };
+      }
+
+      const searchOptions: Record<string, unknown> = {
+        numResults,
+        type,
+      };
+
+      if (Object.keys(contents).length > 0) {
+        searchOptions.contents = contents;
+      }
+
+      if (typeof subpages === "number" && subpages > 0) {
+        searchOptions.subpages = subpages;
+        if (subpageTargets?.length) {
+          searchOptions.subpageTarget = subpageTargets;
+        }
+      }
+
+      searchOptions.livecrawl = livecrawl;
+
+      if (category) {
+        searchOptions.category = category;
+      }
+
+      if (startCrawlDate) {
+        searchOptions.startCrawlDate = startCrawlDate;
+      }
+
+      if (endCrawlDate) {
+        searchOptions.endCrawlDate = endCrawlDate;
+      }
+
+      const result = await exa.searchAndContents(query, searchOptions);
+
+      return {
+        query,
+        results: result.results.map((r: ExaSearchResult) => ({
+          title: r.title,
+          url: r.url,
+          author: r.author,
+          publishedDate: r.publishedDate,
+          highlights: r.highlights ?? [],
+          summary: r.summary,
+          fullText: includeText ? r.text : undefined,
+          snippet: r.text ? `${r.text.slice(0, 500)}...` : undefined,
+          subpages: r.subpages?.map((subpage: ExaSubpage) => ({
+            title: subpage.title,
+            url: subpage.url,
+            highlights: subpage.highlights ?? [],
+            summary: subpage.summary,
+            fullText: includeText ? subpage.text : undefined,
+          })),
+        })),
+        message: `Found ${result.results.length} results for: ${query}`,
+      };
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error));
+      console.error(`Exa search failed for query "${query}":`, err);
+
+      return {
+        error: err.message,
+        results: [],
+        query,
+        message:
+          "Exa search encountered an error. Please continue with other available information or try a different query.",
+      };
+    }
+  },
+  {
+    name: "exa_search",
+    description:
+      "Perform semantic web search using Exa's neural search engine. Returns structured results with highlights, summaries, and optional full text content.",
+    schema: z.object({
+      query: z.string().describe("The search query"),
+      numResults: z
+        .number()
+        .min(1)
+        .max(100)
+        .optional()
+        .default(10)
+        .describe("Number of results to return"),
+      type: z
+        .enum(["auto", "neural", "keyword"])
+        .optional()
+        .default("auto")
+        .describe("Search strategy"),
+      includeText: z
+        .boolean()
+        .optional()
+        .default(true)
+        .describe("Whether to include full text content"),
+      includeHighlights: z
+        .boolean()
+        .optional()
+        .default(true)
+        .describe("Whether to request highlighted excerpts"),
+      highlightQuery: z
+        .string()
+        .optional()
+        .describe("Custom query for highlight generation"),
+      numHighlightSentences: z
+        .number()
+        .min(1)
+        .max(10)
+        .optional()
+        .default(4)
+        .describe("Number of sentences per highlight"),
+      summaryQuery: z
+        .string()
+        .optional()
+        .describe("Prompt for AI-generated summaries"),
+      subpages: z
+        .number()
+        .min(0)
+        .max(8)
+        .optional()
+        .default(0)
+        .describe("Number of subpages to fetch for each result"),
+      subpageTargets: z
+        .array(z.string())
+        .optional()
+        .describe("Preferred subpage keywords or sections"),
+      livecrawl: z
+        .enum(["always", "never", "asAvailable"])
+        .optional()
+        .default("always")
+        .describe("Whether to live crawl pages"),
+      category: EXA_CATEGORY.optional().describe("Content category filter"),
+      startCrawlDate: z
+        .string()
+        .optional()
+        .describe("Start date for crawled content (YYYY-MM-DD)"),
+      endCrawlDate: z
+        .string()
+        .optional()
+        .describe("End date for crawled content (YYYY-MM-DD)"),
+    }),
+  }
+);
 
 export const internetSearch = tool(
   async ({
@@ -88,6 +309,14 @@ export const internetSearch = tool(
  */
 export async function loadResearchTools(): Promise<LoadedTool[]> {
   const tools: LoadedTool[] = [];
+
+  if (process.env.EXA_API_KEY) {
+    tools.push(exaSearch as LoadedTool);
+  } else {
+    console.warn(
+      "EXA_API_KEY not set. The exa_search tool will be unavailable."
+    );
+  }
 
   if (process.env.TAVILY_API_KEY) {
     tools.push(internetSearch as LoadedTool);

--- a/apps/agent/src/types/exa-js.d.ts
+++ b/apps/agent/src/types/exa-js.d.ts
@@ -1,0 +1,28 @@
+declare module "exa-js" {
+  interface ExaSubpage {
+    title?: string;
+    url: string;
+    text?: string;
+    highlights?: unknown[];
+    summary?: unknown;
+  }
+
+  interface ExaResult extends ExaSubpage {
+    author?: string;
+    publishedDate?: string;
+    subpages?: ExaSubpage[];
+  }
+
+  interface ExaSearchResponse {
+    results: ExaResult[];
+  }
+
+  export default class Exa {
+    constructor(apiKey: string);
+
+    searchAndContents(
+      query: string,
+      options?: Record<string, unknown>
+    ): Promise<ExaSearchResponse>;
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "@langchain/mcp-adapters": "^0.6.0",
         "@langchain/tavily": "^0.1.5",
         "deepagents": "^0.0.2",
+        "exa-js": "^1.9.3",
         "jose": "^5.9.3"
       },
       "devDependencies": {
@@ -2005,7 +2006,6 @@
       "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.3.78.tgz",
       "integrity": "sha512-Nn0x9erQlK3zgtRU1Z8NUjLuyW0gzdclMsvLQ6wwLeDqV91pE+YKl6uQb+L2NUDs4F0N7c2Zncgz46HxrvPzuA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
         "ansi-styles": "^5.0.0",
@@ -2070,7 +2070,6 @@
       "resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-0.4.9.tgz",
       "integrity": "sha512-+rcdTGi4Ium4X/VtIX3Zw4RhxEkYWpwUyz806V6rffjHOAMamg6/WZDxpJbrP33RV/wJG1GH12Z29oX3Pqq3Aw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@langchain/langgraph-checkpoint": "^0.1.1",
         "@langchain/langgraph-sdk": "~0.1.0",
@@ -2139,7 +2138,6 @@
       "resolved": "https://registry.npmjs.org/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-0.1.1.tgz",
       "integrity": "sha512-h2bP0RUikQZu0Um1ZUPErQLXyhzroJqKRbRcxYRTAh49oNlsfeq4A3K4YEDRbGGuyPZI/Jiqwhks1wZwY73AZw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "uuid": "^10.0.0"
       },
@@ -3652,7 +3650,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.15.tgz",
       "integrity": "sha512-+kLxJpaJzXybyDyFXYADyP1cznTO8HSuBpenGlnKOAkH4hyNINiywvXS/tGJhsrGGP/gM185RA3xpjY0Yg4erA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -3663,7 +3660,6 @@
       "integrity": "sha512-qXRuZaOsAdXKFyOhRBg6Lqqc0yay13vN7KrIg4L7N4aaHN68ma9OK3NE1BoDFgFOTfM7zg+3/8+2n8rLUH3OKQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
@@ -3760,7 +3756,6 @@
       "integrity": "sha512-TGf22kon8KW+DeKaUmOibKWktRY8b2NSAZNdtWh798COm1NWx8+xJ6iFBtk3IvLdv6+LGLJLRlyhrhEDZWargQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.45.0",
         "@typescript-eslint/types": "8.45.0",
@@ -4310,7 +4305,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4764,7 +4758,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.3",
         "caniuse-lite": "^1.0.30001741",
@@ -5131,7 +5124,6 @@
       "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -5277,6 +5269,15 @@
       },
       "bin": {
         "create-langgraph": "dist/cli.mjs"
+      }
+    },
+    "node_modules/cross-fetch": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
+      "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.7.0"
       }
     },
     "node_modules/cross-spawn": {
@@ -6129,7 +6130,6 @@
       "integrity": "sha512-hB4FIzXovouYzwzECDcUkJ4OcfOEkXTv2zRY6B9bkwjx/cprAq0uvm1nl7zvQ0/TsUk0zQiN4uPfJpB9m+rPMQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6304,7 +6304,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6607,6 +6606,31 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/exa-js": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/exa-js/-/exa-js-1.9.3.tgz",
+      "integrity": "sha512-4u8vO5KHstifBz6fcwcBVvU62zfwsWFpD8qomU2zQ+lLRYCwOh2Rz04xSSqEeoHrkCypGjy2VHez7elBt6ibQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-fetch": "~4.1.0",
+        "dotenv": "~16.4.7",
+        "openai": "^5.0.1",
+        "zod": "^3.22.0",
+        "zod-to-json-schema": "^3.20.0"
+      }
+    },
+    "node_modules/exa-js/node_modules/dotenv": {
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/execa": {
       "version": "9.6.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.0.tgz",
@@ -6652,7 +6676,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
       "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.0",
@@ -7690,7 +7713,6 @@
       "integrity": "sha512-Hxw4wT6zjJGZJdkJzAx9PyBdf7ZpxaTSA0NfxqjLghwMrLBX8p33hJBzoETRakF3UJu6OdNQBZAlNSkGqKFukw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -10116,7 +10138,6 @@
       "resolved": "https://registry.npmjs.org/next/-/next-15.5.4.tgz",
       "integrity": "sha512-xH4Yjhb82sFYQfY3vbkJfgSDgXvBB6a8xPs9i35k6oZJRoQRihZH+4s9Yo2qsWpzBmZ3lPXaJ2KPXLfkvW4LnA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@next/env": "15.5.4",
         "@swc/helpers": "0.5.15",
@@ -10172,6 +10193,26 @@
       "peerDependencies": {
         "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
         "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/node-releases": {
@@ -10425,6 +10466,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/openai": {
+      "version": "5.23.2",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-5.23.2.tgz",
+      "integrity": "sha512-MQBzmTulj+MM5O8SKEk/gL8a7s5mktS9zUtAkU257WjvobGc9nKcBuVwjyEEcb9SI8a8Y2G/mzn3vm9n1Jlleg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/optionator": {
@@ -10724,7 +10786,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
@@ -10847,7 +10908,6 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -11119,7 +11179,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
       "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11129,7 +11188,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
       "integrity": "sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -12587,8 +12645,7 @@
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.13.tgz",
       "integrity": "sha512-i+zidfmTqtwquj4hMEwdjshYYgMbOrPzb9a0M3ZgNa0JMoZeFC6bxZvO8yr8ozS6ix2SDz0+mvryPeBs2TFE+w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tailwindcss-animate": {
       "version": "1.0.7",
@@ -12682,7 +12739,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12711,6 +12767,12 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
     },
     "node_modules/tree-kill": {
       "version": "1.2.2",
@@ -12931,7 +12993,6 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13364,6 +13425,22 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -13693,7 +13770,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -13703,7 +13779,6 @@
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz",
       "integrity": "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==",
       "license": "ISC",
-      "peer": true,
       "peerDependencies": {
         "zod": "^3.24.1"
       }


### PR DESCRIPTION
## Summary
- ensure the Exa deep-research tool instantiates the SDK correctly, always opts into live crawling, and returns typed highlights, summaries, and subpages
- add ambient TypeScript declarations for `exa-js` so full-text payloads and subpage data are exposed without `any`
- bump the LangGraph SDK dependency to 0.1.9 and annotate deep agent exports to avoid non-portable inferred types

## Testing
- `npm run typecheck --workspace apps/agent`


------
https://chatgpt.com/codex/tasks/task_e_68dcb92eae6483239ffb039ef7f7ac5d